### PR TITLE
remove unused framework bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^3.3",
         "contao/core-bundle": "^4.4"
     },
     "replace": {


### PR DESCRIPTION
You are not actually using any component of the symfony/framework-bundle, yet you required it in your composer.json.

This fixes #4 